### PR TITLE
Add ttlSecondsAfterFinished to populate-oscar-volume-job: Fix #61

### DIFF
--- a/oscar/Chart.yaml
+++ b/oscar/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Open Source Serverless Computing for Data-Processing Applications
 name: oscar
-version: 3.0.0
+version: 3.0.1
 sources:
 - https://github.com/grycap/oscar
 home: https://grycap.github.io/oscar

--- a/oscar/templates/populate-oscar-volume-job.yaml
+++ b/oscar/templates/populate-oscar-volume-job.yaml
@@ -5,6 +5,7 @@ metadata:
   name: populate-volume-job
   namespace: {{ .Values.servicesNamespace | quote }}
 spec:
+  ttlSecondsAfterFinished: 120
   template:
     spec:
       containers:


### PR DESCRIPTION
The ttlSecondsAfterFinished enables the deletion of the job once finished, avoiding the error in the upgrade process.