### PR TITLE
Add kserve configuration and update RBAC permissions

### DIFF
--- a/oscar/templates/oscar-deployment.yaml
+++ b/oscar/templates/oscar-deployment.yaml
@@ -190,6 +190,8 @@ spec:
           value: {{ .Values.minIO.quota.buckets | quote }}
         - name: MINIO_QUOTA_STORAGE
           value: {{ .Values.minIO.quota.storage | quote }}
+        - name: KSERVE_ENABLE
+          value: {{ .Values.kserve.enable | quote }}
         ports:
         - name: http
           containerPort: {{ .Values.service.port }}

--- a/oscar/templates/oscar-rbac.yaml
+++ b/oscar/templates/oscar-rbac.yaml
@@ -351,6 +351,16 @@ rules:
   - create
   - delete
   - update
+- apiGroups:
+  - serving.kserve.io
+  resources:
+  - inferenceservices
+  - llminferenceservices
+  verbs:
+  - create
+  - delete
+  - update
+  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/oscar/values.yaml
+++ b/oscar/values.yaml
@@ -144,6 +144,10 @@ kueue:
     memory: "2Gi"
     flavor: "oscar-default-flavor"
 
+# Configure kserve resource
+kserve:
+  enable: "false"
+
 # Configure Prometheus resource
 
 prometheus:


### PR DESCRIPTION
Configuration and deployment:

* Added a new `kserve` configuration section in `oscar/values.yaml` to enable or disable KServe integration.
* Updated `oscar-deployment.yaml` to set the `KSERVE_ENABLE` environment variable in the deployment based on the new configuration value.

RBAC permissions:

* Extended the RBAC rules in `oscar-rbac.yaml` to allow creating, deleting, updating, and getting `inferenceservices` and `llminferenceservices` resources from the `serving.kserve.io` API group, which are required for KServe integration.